### PR TITLE
fix bugs

### DIFF
--- a/data.json
+++ b/data.json
@@ -4146,12 +4146,6 @@
         "md5": "525c4fc0129a84f864d7a71ee4f30a2b"
     },
     {
-        "url": "/Inc/NoSqlHack.Asp",
-        "re": "",
-        "name": "southidc",
-        "md5": "d41d8cd98f00b204e9800998ecf8427e"
-    },
-    {
         "url": "/style/default/hdwiki.css",
         "re": "",
         "name": "HDwiki",
@@ -7152,12 +7146,6 @@
         "md5": "bb2df5d4a43793e80be55a27170dd8bb"
     },
     {
-        "url": "/download.jsp",
-        "re": "",
-        "name": "MinyooCMS",
-        "md5": "d41d8cd98f00b204e9800998ecf8427e"
-    },
-    {
         "url": "/App_Image/Public/select.gif",
         "re": "",
         "name": "天柏在线考试系统",
@@ -7888,12 +7876,6 @@
         "re": "",
         "name": "easy7视频监控平台",
         "md5": "bb2df5d4a43793e80be55a27170dd8bb"
-    },
-    {
-        "url": "/download.jsp",
-        "re": "",
-        "name": "MinyooCMS",
-        "md5": "d41d8cd98f00b204e9800998ecf8427e"
     },
     {
         "url": "/content/platcontentnew/images/baselogin/loginsj.png",

--- a/gwhatweb.py
+++ b/gwhatweb.py
@@ -19,7 +19,7 @@ class gwhatweb(object):
 		
     def _GetMd5(self,body):
         m2 = hashlib.md5()
-        m2.update(body)
+        m2.update(body.encode("utf8"))
         return m2.hexdigest()
 
     def _clearQueue(self):


### PR DESCRIPTION
fix UnicodeEncodeError when using python2.7,
fix TypeError when using python3

使用python2环境的时候，会报UnicodeEncodeError

![f9d106fa-a2c9-4071-86e3-649e34a1a42f](https://user-images.githubusercontent.com/15107549/42310929-303335ec-806f-11e8-9455-4b367cd724ba.png)

使用Python3环境的时候，会报TypeError
![70fbd949-f2ff-4ccc-a12d-a4aee0ea0eaf](https://user-images.githubusercontent.com/15107549/42310865-06a048fa-806f-11e8-9717-b3c1e6155e73.png)

update()时指定要加密的字符串的字符编码，就不会报错了~

参考:
[关于python2.7的md5加密遇到的问题（TypeError: Unicode-objects must be encoded before hashing](https://blog.csdn.net/u012087740/article/details/48439559)
[Python 用hashlib求中文字符串的MD5值](https://blog.csdn.net/haungrui/article/details/6959340)

---


修改的特征文件里面，删掉的3个特征里的md5均为d41d8cd98f00b204e9800998ecf8427e，这是空字符串的MD5值,拿这个作为特征似乎容易误报。
识别`http://www.washun.com/`的时候，结果为

```
CMS:southidc Judge:http://www.washun.com/Inc/NoSqlHack.Asp md5:d41d8cd98f00b204e9800998ecf8427e

CMS:MinyooCMS Judge:http://www.washun.com/download.jsp md5:d41d8cd98f00b204e9800998ecf8427e

CMS:MinyooCMS Judge:http://www.washun.com/download.jsp md5:d41d8cd98f00b204e9800998ecf8427e
```

访问这些页面均为404